### PR TITLE
feat: make Docker container deployable anywhere + dev env setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,7 +1,0 @@
-{
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": "."
-  },
-  "terminals": []
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,3 +160,12 @@ scripts/             # Build automation scripts
 - **Path References**: Use relative paths, maintain flat directory structure
 - **Build Testing**: Always test builds locally - broken builds break deployment
 - **Statistics**: Re-generate stats after significant content changes
+
+## Cursor Cloud specific instructions
+
+- **Virtual environment**: After the update script runs, activate with `source .venv/bin/activate` before running any Python or `mkdocs` commands.
+- **Unified CLI**: The AGENTS.md "Build Commands" section references legacy scripts (`build.py`, `serve.py`, `site_tester.py`, `check_media_paths.py`, etc.) that no longer exist. The actual tool is `python site_manager.py <command>`. Key subcommands: `build`, `serve`, `optimize`, `stats`, `test`, `check`, `clean`.
+- **Dev server binding**: Use `--host 0.0.0.0` when starting the dev server so it is reachable from the browser: `python site_manager.py serve --host 0.0.0.0`.
+- **Build time**: Initial build takes ~28 seconds for 460+ pages. Use `--no-optimize` to skip image conversion during development.
+- **Testing before commit**: Run `python site_manager.py build --no-optimize` and `python site_manager.py test` to validate the site. `python site_manager.py check` validates media paths.
+- **No external services required**: This is a pure static site generator; no databases, Docker, or Node.js needed for development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR Content

This PR is about

- [x] Something else (see below)

## Comments

### Docker container: deploy anywhere

The existing Docker setup was hardcoded for `0xfab1.net` with mandatory HTTPS/certbot, making it impossible to host elsewhere. This PR makes the container work on any host:

**HTTP-only mode (default)** — just works, no config needed:
```bash
docker run -p 8080:80 0xfab1
```

**HTTPS mode** — opt-in via environment variables:
```bash
docker run -e ENABLE_SSL=true -e DOMAIN=example.com \
  -p 80:80 -p 443:443 0xfab1
```

#### Changes

- **`nginx.conf`**: Replaced hardcoded `server_name 0xfab1.net` + HTTPS redirect with a generic `default_server` on port 80. HTTPS config is dynamically included from `conf.d/` when SSL is enabled.
- **`entrypoint.sh`**: Defaults to HTTP-only mode (`exec nginx`). When `ENABLE_SSL=true` and `DOMAIN` are set, generates an SSL server block, obtains a Let's Encrypt cert via certbot, and runs renewal in background.
- **`.dockerignore`**: Added `.venv/`, `site/`, `__pycache__/`, `.cache/`, `.cursor/` to reduce build context.

### Dev environment setup

- **`AGENTS.md`**: Added `## Cursor Cloud specific instructions` section documenting unified CLI (`site_manager.py`), dev server binding, build tips, and testing commands.
- **Deleted `.cursor/environment.json`**: Removed so snapshot-managed environment settings take effect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1efeb8ad-5722-434d-874b-8b61e083c92e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1efeb8ad-5722-434d-874b-8b61e083c92e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

