### PR TITLE
feat: make Docker container deployable anywhere

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,8 @@ certbot/
 *.md
 .github/
 .dockerignore
+.venv/
+site/
+__pycache__/
+.cache/
+.cursor/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,24 +1,86 @@
 #!/bin/sh
+set -e
 
-# Create dummy certificate if it doesn't exist
-if [ ! -f /etc/letsencrypt/live/0xfab1.net/fullchain.pem ]; then
-    echo "Creating dummy certificate for 0xfab1.net"
-    mkdir -p /etc/letsencrypt/live/0xfab1.net
-    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
-        -keyout "/etc/letsencrypt/live/0xfab1.net/privkey.pem" \
-        -out "/etc/letsencrypt/live/0xfab1.net/fullchain.pem" \
-        -subj "/CN=0xfab1.net"
+DOMAIN="${DOMAIN:-}"
+EMAIL="${EMAIL:-admin@${DOMAIN}}"
+ENABLE_SSL="${ENABLE_SSL:-false}"
+
+# ---------------------------------------------------------------------------
+# SSL mode: obtain/renew Let's Encrypt certificates for the given DOMAIN.
+# Usage:  docker run -e ENABLE_SSL=true -e DOMAIN=example.com -p 80:80 -p 443:443 ...
+# ---------------------------------------------------------------------------
+if [ "$ENABLE_SSL" = "true" ] && [ -n "$DOMAIN" ]; then
+    echo "SSL mode enabled for ${DOMAIN}"
+
+    # Generate a temporary self-signed cert so nginx can start with SSL
+    if [ ! -f "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem" ]; then
+        echo "Creating temporary self-signed certificate for ${DOMAIN}"
+        mkdir -p "/etc/letsencrypt/live/${DOMAIN}"
+        openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
+            -keyout "/etc/letsencrypt/live/${DOMAIN}/privkey.pem" \
+            -out "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem" \
+            -subj "/CN=${DOMAIN}" 2>/dev/null
+    fi
+
+    # Write an HTTPS server block for this domain
+    cat > /etc/nginx/conf.d/ssl.conf <<EOF
+server {
+    listen 443 ssl http2;
+    server_name ${DOMAIN} www.${DOMAIN};
+
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options DENY always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    location / {
+        try_files \$uri \$uri/ =404;
+    }
+
+    location = /favicon.ico { log_not_found off; access_log off; }
+    location = /robots.txt  { log_not_found off; access_log off; }
+
+    location ~* \.(css|js|png|jpg|jpeg|gif|ico|svg|webp|woff2?)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}
+EOF
+
+    # Start nginx in background, then request a real certificate
+    nginx -g "daemon off;" &
+    NGINX_PID=$!
+    sleep 5
+
+    certbot --nginx --non-interactive --agree-tos --email "${EMAIL}" -d "${DOMAIN}" || true
+
+    # Renew certificates every 12 hours
+    while :; do
+        certbot renew --nginx --quiet || true
+        sleep 12h
+    done &
+
+    wait $NGINX_PID
+
+# ---------------------------------------------------------------------------
+# HTTP-only mode (default): just serve on port 80 — works anywhere.
+# Usage:  docker run -p 8080:80 image_name
+# ---------------------------------------------------------------------------
+else
+    echo "Starting in HTTP-only mode on port 80"
+    echo "Tip: Set ENABLE_SSL=true and DOMAIN=yourdomain.com for HTTPS"
+    exec nginx -g "daemon off;"
 fi
-
-# Start nginx
-nginx -g "daemon off;" &
-sleep 8
-
-# Get Cert
-certbot --nginx --non-interactive --agree-tos --email admin@0xfab1.net -d 0xfab1.net
-
-# Renew certificates every 12 hours
-while :; do
-    certbot renew --nginx
-    sleep 12h
-done

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,13 +8,13 @@ events {
 http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
-    
+
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
-    
+
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;
@@ -28,66 +28,48 @@ http {
         application/javascript
         application/xml+rss
         application/json;
-    
-    # HTTP Server - redirects to HTTPS
+
+    # Default HTTP server — serves the site on port 80
     server {
-        listen 80;
-        server_name 0xfab1.net www.0xfab1.net;
-        
-        # Let's Encrypt challenge location
+        listen 80 default_server;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+
+        # Let's Encrypt challenge location (used when ENABLE_SSL=true)
         location /.well-known/acme-challenge/ {
             root /var/www/certbot;
         }
-        
-        # Redirect all other HTTP traffic to HTTPS
-        location / {
-            return 301 https://$server_name$request_uri;
-        }
-    }
-    
-    # HTTPS Server
-    server {
-        listen 443 ssl http2;
-        server_name 0xfab1.net www.0xfab1.net;
-        
-        # SSL Configuration
-        ssl_certificate /etc/letsencrypt/live/0xfab1.net/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/0xfab1.net/privkey.pem;
-        
-        # Modern SSL configuration
-        ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
-        ssl_prefer_server_ciphers off;
-        ssl_session_cache shared:SSL:10m;
-        ssl_session_timeout 10m;
-        
+
         # Security headers
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options DENY always;
         add_header X-Content-Type-Options nosniff always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        
+
         location / {
             try_files $uri $uri/ =404;
         }
-        
+
         location = /favicon.ico {
             log_not_found off;
             access_log off;
         }
-        
+
         location = /robots.txt {
             log_not_found off;
             access_log off;
         }
-        
-        location ~* \.(css|js|png|jpg|jpeg|gif|ico|svg)$ {
+
+        location ~* \.(css|js|png|jpg|jpeg|gif|ico|svg|webp|woff2?)$ {
             expires 1y;
             add_header Cache-Control "public, immutable";
         }
     }
+
+    # HTTPS server — only active when SSL certificates are present.
+    # To enable: run with ENABLE_SSL=true and DOMAIN=yourdomain.com
+    # or mount your own certs into /etc/letsencrypt/live/<domain>/
+    include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
- nginx.conf: replace hardcoded 0xfab1.net server blocks with a generic HTTP default_server on port 80; HTTPS config is dynamically generated via include conf.d when SSL is enabled
- entrypoint.sh: default to HTTP-only mode (just nginx, no certbot); optional SSL mode activated via ENABLE_SSL=true and DOMAIN env vars, which generates ssl.conf and runs certbot automatically
- .dockerignore: add .venv/, site/, __pycache__/, .cache/, .cursor/ to reduce build context size

Usage:
  HTTP:  docker run -p 8080:80 0xfab1 HTTPS: docker run -e ENABLE_SSL=true -e DOMAIN=example.com \ -p 80:80 -p 443:443 0xfab1

# PR

Thanks for your pull request!

## Pre-Checks

Let's have an agreement :)

- [ ] I've read the [contribution guidelines](https://github.com/FullByte/FullByte.github.io/blob/master/CONTRIBUTING.md) and agree with them!
- [ ] I've tested my change, [built it](https://github.com/FullByte/FullByte.github.io#build) and everything works!

## PR Content

This PR is about

- [ ] Missing or wrong links
- [ ] Typos and wording
- [ ] You didn't mention me where credit is due
- [ ] Something you posted is wrong and needs correction
- [ ] Something else (see below)

## Comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes container startup and Nginx TLS/certbot behavior; misconfiguration of `DOMAIN`/ports or cert generation could break HTTPS startup or renewals. No application/business logic is affected.
> 
> **Overview**
> Makes the Dockerized Nginx setup domain-agnostic by removing the hardcoded `0xfab1.net` HTTPS/redirect config and replacing it with a generic port-80 `default_server` plus an `include /etc/nginx/conf.d/*.conf` hook for optional SSL.
> 
> Updates `entrypoint.sh` to default to **HTTP-only** serving, with an opt-in **SSL mode** (`ENABLE_SSL=true`, `DOMAIN`, optional `EMAIL`) that generates an `ssl.conf`, bootstraps a temporary self-signed cert, runs `certbot` to obtain/renew Let’s Encrypt certs, and renews in the background.
> 
> Reduces Docker build context size by ignoring common local/dev artifacts in `.dockerignore` (e.g., `.venv/`, `__pycache__/`, `.cache/`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fc5b76f37864ba64b7689f8bacbbd37f4cc809b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->